### PR TITLE
Add asyncua to OPC UA Gateway requirements.

### DIFF
--- a/opcua/gateway/requirements_docker.txt
+++ b/opcua/gateway/requirements_docker.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 prometheus-client
 uvloop
+asyncua

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "fastapi",
+    "asyncua",
     "flake8",
     "tomlkit",
 ]


### PR DESCRIPTION
Add `asyncua` to OPC UA Gateway requirements.