### PR TITLE
Refactor the opc ua connector using the new connector framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Each connector is responsible for collecting data from a specific protocol or ec
 
 ## 🔗 Supported Connectors
 
-- **[OPC UA](opcua)**  
+- **[OPC UA](src/connectors/opcua)**  
   - `OPCUA-Coordinator`: assigns devices to gateways.  
   - `OPCUA-Gateway`: connects to one or more OPC UA servers, collects data, and streams to Kafka.
 
@@ -27,12 +27,11 @@ Each connector is responsible for collecting data from a specific protocol or ec
 ## 📂 Repository Structure
 
 ```
-openfactory-connectors/
+openfactory-connectors/src/connectors
 ├── opcua/          # OPC UA connectors (Coordinator + Gateway)
-├── shdr/           # SHDR connector (planned)
+├── shdr/           # SHDR connector
 ├── mqtt/           # MQTT connector (planned)
-├── modbus/         # Modbus connector (planned)
-└── README.md       # General repository documentation
+└── modbus/         # Modbus connector (planned)
 ```
 
 ## 🚀 Usage

--- a/opcua/README.md
+++ b/opcua/README.md
@@ -1,5 +1,7 @@
 # OPC UA Connector for OpenFactory
 
+**⚠️ OBSOLETE CODE - WILL BE REMOVE IN FUTURE RELEASES ⚠️**
+
 The **OPC UA Connector** enables seamless integration between industrial equipment that speaks the **OPC UA protocol** and the **OpenFactory platform**.
 
 It acts as a bridge between **shop-floor devices** and the **cloud-native data infrastructure**:

--- a/src/connectors/opcua/README.md
+++ b/src/connectors/opcua/README.md
@@ -1,0 +1,105 @@
+# OPC UA Connector for OpenFactory
+
+The **OPC UA Connector** enables seamless integration between industrial equipment that speaks the **OPC UA protocol** and the **OpenFactory platform**.
+
+It acts as a bridge between **shop-floor devices** and the **cloud-native data infrastructure**:
+
+* **OPC UA Devices** expose machine data.
+* **OPCUA-Gateways** connect to those devices, collect the raw data, normalize it, and publish it into **Kafka**, OpenFactory’s event backbone.
+* **OPCUA-Coordinator** orchestrates multiple gateways, deciding which gateway should handle which devices. This allows OpenFactory to scale horizontally and balance the load across gateways.
+
+In short:
+- The **Coordinator** ensures **smart distribution of devices across gateways**.
+- The **Gateways** ensure **reliable data ingestion from machines into Kafka**.
+
+Together, they allow OpenFactory to handle **many devices across the factory** while staying resilient, scalable, and simple to manage.
+
+## 🛰️ OPCUA-Coordinator
+
+- Receives requests to connect OPC UA devices to OpenFactory.
+- Decides which `OPCUA-Gateway` should manage which devices.
+- Communicates assignment updates to gateways.
+
+## 🌐 OPCUA-Gateway
+
+- Connects to one or more OPC UA devices.
+- Collects data from devices.
+- Streams normalized messages into OpenFactory (Kafka).
+- Multiple gateways can be deployed for scalability.
+
+## ⚙️ Configuration
+
+### Environment Variables (Coordinator)
+
+| Variable                      | Description                    | Default     |
+| ----------------------------- | ------------------------------ | ----------- |
+| `OPCUA_COORDINATOR_LOG_LEVEL` | Log level                      | INFO        |
+
+### Environment Variables (Gateway)
+
+| Variable                  | Description                           | Default     |
+| ------------------------- | ------------------------------------- | ----------- |
+| `OPCUA_GATEWAY_LOG_LEVEL` | Log level                             | INFO        |
+| `KAFKA_LINGER_MS`         | Kafka producer linger in ms           | 5           |
+
+## 📋 Prerequisites
+
+Before deploying the Connector stack, make sure you have an OpenFactory infrastructure up and running. This includes:
+
+* A running **Kafka** cluster and **ksqlDB** instance.
+* A **Docker network** created for your factory services
+
+For more details refere to the documentation in [openfactory-core](https://github.com/openfactoryio/openfactory-core).
+
+
+## 🚀 Deployment on an OpenFactory Cluster
+
+### 1️⃣ Configure OPC UA Connector stack
+
+Both, coordinator and gateway, are OpenFactory applications.
+
+Create a `opcua-connector.yml` OpenFActory configuration file with your desired configuration.
+Example for **two Gateways**:
+
+```yml
+apps:
+
+  opcua-coordinator:
+    uuid: OPCUA-COORDINATOR
+    image: ghcr.io/openfactoryio/opcua-coordinator:<VERSION>
+    environment:
+      - LOG_LEVEL=DEBUG
+    networks:
+      - factory-net
+
+  opcua-gateway-1:
+    uuid: OPCUA-GATEWAY-1
+    image: ghcr.io/openfactoryio/opcua-gateway:<VERSION>
+    environment:
+      - LOG_LEVEL=DEBUG
+      - KAFKA_LINGER_MS=10
+    networks:
+      - factory-net
+
+  opcua-gateway-2:
+    uuid: OPCUA-GATEWAY-2
+    image: ghcr.io/openfactoryio/opcua-gateway:<VERSION>
+    environment:
+      - LOG_LEVEL=DEBUG
+      - KAFKA_LINGER_MS=10
+    networks:
+      - factory-net
+```
+
+Notes:
+* Replace `<VERSION>` with the matching **OpenFactory platform version** (e.g. `v1.2.3`).
+* You can set environment variables directly in the file instead of importing local environment variables with `${...}`.
+* The `uuid` of the coordinator and the gateway can be freely choosen and are discovered by the applications. 
+
+### 2️⃣ Deploy the stack
+
+```bash
+ofa apps up opcua-connector.yml
+```
+
+This will launch the Coordinator and Gateways inside your OpenFactory cluster.

--- a/src/connectors/opcua/coordinator/Dockerfile
+++ b/src/connectors/opcua/coordinator/Dockerfile
@@ -1,0 +1,78 @@
+# ------------------------------------------------------------------------------
+# 🐳 Dockerfile for OPCUA Coordinator (FastAPI)
+#
+# This image is used in both development and production environments.
+# It installs required system dependencies, sets up a non-root user,
+# installs Python packages, and runs the app.
+#
+# Key Features:
+#   - Uses Python 3.12-slim base for small footprint
+#   - Runs as a non-root user for better container security
+#   - Compatible with both local and Swarm deployments
+#
+# build:
+#   cd src
+#   docker build -f connectors/opcua/coordinator/Dockerfile -t opcua-coordinator .
+# ------------------------------------------------------------------------------
+
+# ---- builder stage ----
+FROM python:3.12-slim AS builder
+
+# Argument for version management
+ARG OFA_VERSION=main
+
+# Install git
+RUN apt-get update && apt-get install -y git
+
+# Create virtualenv
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Install dependencies
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir \
+       "openfactory[fastapi] @ git+https://github.com/openfactoryio/openfactory-core.git@${OFA_VERSION}"
+
+# ---- final stage ----
+FROM python:3.12-slim
+
+# Arguments for non-root user creation
+ARG UNAME=opcua-coordinator
+ARG UID=1200
+ARG GID=1200
+
+# Argument for version management
+ARG VERSION=dev
+
+# Create runtime user/group
+RUN groupadd --gid $GID $UNAME \
+    && useradd --create-home --uid $UID --gid $GID $UNAME
+
+# Security: no package manager leftovers
+RUN rm -rf /var/lib/apt/lists/*
+
+# Copy virtualenv from builder
+COPY --from=builder /opt/venv /opt/venv
+
+# Activate it
+ENV PATH="/opt/venv/bin:$PATH"
+
+# App setup
+WORKDIR /app
+RUN mkdir -p connectors/common
+RUN mkdir -p connectors/opcua/coordinator
+COPY connectors/common connectors/common
+COPY connectors/opcua/coordinator connectors/opcua/coordinator
+
+# Change ownership to the non-root user
+RUN chown -R $UNAME:$UNAME /app
+
+# Set environment variables
+ENV APPLICATION_VERSION=${VERSION}
+ENV PYTHONUNBUFFERED=1
+
+# Switch to non-root user
+USER $UNAME
+
+# Command to run the bridge
+ENTRYPOINT ["python", "-m", "connectors.opcua.coordinator.src.main"]

--- a/src/connectors/opcua/coordinator/app_opcua_coordinator.yml
+++ b/src/connectors/opcua/coordinator/app_opcua_coordinator.yml
@@ -1,0 +1,26 @@
+# ---------------------------------------------------------------------------------------
+# 🏭 OpenFactory App configuration file for the OPCUA Coordinator
+#
+# Deploy with:
+#   ofa device up app_opcua_coordinator.yml
+# ---------------------------------------------------------------------------------------
+# Environment variables:
+#
+# Optional:
+#   OPCUA_COORDINATOR_LOG_LEVEL    Log level (default: INFO)
+#
+# ---------------------------------------------------------------------------------------
+
+apps:
+
+  opcua-coordinator:
+    uuid: OPCUA-COORDINATOR
+    image: opcua-coordinator
+    environment:
+      - LOG_LEVEL=${OPCUA_COORDINATOR_LOG_LEVEL:-DEBUG}
+    routing:
+      expose: true
+      port: 4000
+      hostname: opcua-coordinator
+    networks:
+      - factory-net

--- a/src/connectors/opcua/coordinator/src/main.py
+++ b/src/connectors/opcua/coordinator/src/main.py
@@ -1,0 +1,18 @@
+import os
+from openfactory.kafka import KSQLDBClient
+from connectors.common.coordinator import BaseCoordinator
+from connectors.common.gateway_assignment.round_robin import RoundRobinGatewayAssignmentMixin
+
+
+class OPCUACoordinator(RoundRobinGatewayAssignmentMixin, BaseCoordinator):
+
+    CONNECTOR_NAME = "OPCUA"
+
+
+app = OPCUACoordinator(
+    ksqlClient=KSQLDBClient(os.getenv("KSQLDB_URL")),
+    bootstrap_servers=os.getenv("KAFKA_BROKER"),
+    loglevel=os.getenv("LOG_LEVEL", "DEBUG")
+)
+
+app.run()

--- a/src/connectors/opcua/gateway/Dockerfile
+++ b/src/connectors/opcua/gateway/Dockerfile
@@ -1,0 +1,80 @@
+# ------------------------------------------------------------------------------
+# 🐳 Dockerfile for OPCUA Gateway
+#
+# This image is used in both development and production environments.
+# It installs required system dependencies, sets up a non-root user,
+# installs Python packages, and runs the FastAPI app.
+#
+# Key Features:
+#   - Uses Python 3.12-slim base for small footprint
+#   - Runs as a non-root user for better container security
+#   - Compatible with both local and Swarm deployments
+#
+# build:
+#   cd src
+#   docker build -f connectors/opcua/gateway/Dockerfile -t opcua-gateway .
+# ------------------------------------------------------------------------------
+
+# ---- builder stage ----
+FROM python:3.12-slim AS builder
+
+# Argument for version management
+ARG OFA_VERSION=main
+
+# Install git
+RUN apt-get update && apt-get install -y git
+
+# Create virtualenv
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Install dependencies
+COPY connectors/opcua/gateway/requirements.txt .
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir \
+       "openfactory[fastapi] @ git+https://github.com/openfactoryio/openfactory-core.git@${OFA_VERSION}"
+
+# ---- final stage ----
+FROM python:3.12-slim
+
+# Arguments for non-root user creation
+ARG UNAME=shdr-gateway
+ARG UID=1200
+ARG GID=1200
+
+# Argument for version management
+ARG VERSION=dev
+
+# Create runtime user/group
+RUN groupadd --gid $GID $UNAME \
+    && useradd --create-home --uid $UID --gid $GID $UNAME
+
+# Security: no package manager leftovers
+RUN rm -rf /var/lib/apt/lists/*
+
+# Copy virtualenv from builder
+COPY --from=builder /opt/venv /opt/venv
+
+# Activate it
+ENV PATH="/opt/venv/bin:$PATH"
+
+# App setup
+WORKDIR /app
+RUN mkdir -p connectors/common
+RUN mkdir -p connectors/opcua/gateway
+COPY connectors/common connectors/common
+COPY connectors/opcua/gateway connectors/opcua/gateway
+
+# Change ownership to the non-root user
+RUN chown -R $UNAME:$UNAME /app
+
+# Set environment variables
+ENV APPLICATION_VERSION=${VERSION}
+ENV PYTHONUNBUFFERED=1
+
+# Switch to non-root user
+USER $UNAME
+
+# Command to run the bridge
+ENTRYPOINT ["python", "-m", "connectors.opcua.gateway.src.main"]

--- a/src/connectors/opcua/gateway/app_opcua_gateway.yml
+++ b/src/connectors/opcua/gateway/app_opcua_gateway.yml
@@ -1,0 +1,26 @@
+# ---------------------------------------------------------------------------------------
+# 🏭 OpenFactory App configuration file for the OPCUA Gateway
+#
+# Deploy with:
+#   ofa device up app_shdr_gateway.yml
+# ---------------------------------------------------------------------------------------
+# Environment variables:
+#
+# Optional:
+#   SHDR_GATEWAY_LOG_LEVEL    Log level (default: INFO)
+#
+# ---------------------------------------------------------------------------------------
+
+apps:
+
+  shdr-ocpua-1:
+    uuid: OPCUA-GATEWAY-1
+    image: opcua-gateway
+    environment:
+      - LOG_LEVEL=${OPCUA_GATEWAY_LOG_LEVEL:-DEBUG}
+    routing:
+      expose: true
+      port: 4000
+      hostname: opcua-gateway-1
+    networks:
+      - factory-net

--- a/src/connectors/opcua/gateway/requirements.txt
+++ b/src/connectors/opcua/gateway/requirements.txt
@@ -1,0 +1,2 @@
+# requirements for OPC UA Gateway
+asyncua

--- a/src/connectors/opcua/gateway/src/main.py
+++ b/src/connectors/opcua/gateway/src/main.py
@@ -1,0 +1,134 @@
+import asyncio
+import os
+from openfactory.kafka import KSQLDBClient
+from openfactory.schemas.devices import Device
+from connectors.common.gateway import BaseGateway
+from connectors.common.kafka_producer import GlobalAssetProducer
+from .monitor import DeviceMonitor
+
+
+class OPCUAGateway(BaseGateway):
+    """
+    OPC UA gateway implementation.
+
+    Manages OPC UA device registrations and creates a dedicated
+    monitoring task for each configured device. Monitoring tasks
+    are responsible for maintaining OPC UA sessions, collecting
+    data, exposing commands, and forwarding updates to OpenFactory.
+
+    Attributes:
+        device_tasks (dict[str, asyncio.Task]):
+            Mapping of device UUIDs to active monitoring tasks.
+
+        devices (dict[str, Device]):
+            Mapping of device UUIDs to registered device configurations.
+    """
+
+    CONNECTOR_NAME = "OPCUA"
+
+    # active device runtimes
+    device_tasks: dict[str, asyncio.Task] = {}
+
+    # device configs
+    devices: dict[str, Device] = {}
+
+    def __init__(self, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+        # Global Kafka Producer
+        self.global_producer = GlobalAssetProducer(ksqlClient=self.ksql)
+
+    async def monitor_device(self, device: Device):
+        """
+        Run the monitoring lifecycle for a single OPC UA device.
+
+        This task creates a DeviceMonitor and delegates all device-specific
+        monitoring responsibilities, including:
+
+        - Establishing and maintaining OPC UA sessions
+        - Discovering OPC UA methods and exposing OpenFactory commands
+        - Reading configured constants
+        - Subscribing to variables and events
+        - Forwarding asset updates through the global Kafka producer
+        - Handling reconnects and clean shutdowns
+
+        Args:
+            device (Device): Device schema instance defining OPC UA connector settings.
+        """
+        try:
+            monitor = DeviceMonitor(device, self)
+            self.logger.debug(f"Starting monitoring task {device.uuid}")
+            await monitor.run()
+
+        except asyncio.CancelledError:
+            raise
+
+        except Exception:
+            self.logger.error(
+                f"Unhandled exception while monitoring device {device.uuid}",
+                exc_info=True
+            )
+
+    def connect_device(self, device: Device):
+        """
+        Register a device and start its monitoring task.
+
+        Validates that the device uses the OPC UA connector, creates an
+        asynchronous monitoring task, and stores the task and device
+        references for lifecycle management.
+
+        Args:
+            device (Device): Device to monitor.
+        """
+        if device.connector.type != 'opcua':
+            self.logger.warning(f"Device {device.uuid} is not an OPC UA device.")
+            self.logger.warning(f"Abort registration of {device.uuid}.")
+            return
+        if device.uuid in self.device_tasks:
+            self.logger.warning(f"Device {device.uuid} already connected")
+            return
+
+        self.devices[device.uuid] = device
+
+        try:
+            task = asyncio.create_task(self.monitor_device(device))
+            task.add_done_callback(
+                lambda t: self.logger.error(f"Task for {device.uuid} terminated with {t.exception()!r}")
+                if not t.cancelled() and t.exception()
+                else None
+            )
+        except Exception as e:
+            self.logger.warning(f"Failed to connect device {device.uuid}: {e}", exc_info=True)
+            return
+
+        self.device_tasks[device.uuid] = task
+
+    def disconnect_device(self, device_uuid: str):
+        """
+        Stop monitoring a device.
+
+        Cancels the device monitoring task and removes the device from
+        the internal registries.
+
+        Args:
+            device_uuid (str): UUID of the device to disconnect.
+        """
+        self.logger.info(f"Disconnecting device {device_uuid}")
+
+        task = self.device_tasks.pop(device_uuid, None)
+        if task is None:
+            self.logger.warning(f"Device {device_uuid} had no active task associated.")
+            return
+
+        task.cancel()
+        self.devices.pop(device_uuid, None)
+
+
+app = OPCUAGateway(
+    ksqlClient=KSQLDBClient(os.getenv("KSQLDB_URL")),
+    bootstrap_servers=os.getenv("KAFKA_BROKER"),
+    loglevel=os.getenv("LOG_LEVEL", "INFO")
+)
+
+app.run()

--- a/src/connectors/opcua/gateway/src/monitor.py
+++ b/src/connectors/opcua/gateway/src/monitor.py
@@ -1,0 +1,495 @@
+"""
+Device monitoring module for the OPC UA Gateway.
+
+This module defines the `DeviceMonitor` class, which manages the lifecycle
+of OPC UA devices. Each device monitor handles:
+
+- Parsing the OPC UA connector schema.
+- Establishing and maintaining OPC UA client sessions.
+- Discovering OPC UA methods and exposing them as OpenFactory commands.
+- Reading configured constants.
+- Subscribing to variables and events.
+- Forwarding asset attributes to Kafka via `GlobalAssetProducer`.
+- Automatic reconnection on errors.
+- Cleanup when monitoring tasks are cancelled.
+"""
+
+from __future__ import annotations
+import asyncio
+import traceback
+import re
+import unicodedata
+import json
+from typing import Any, TYPE_CHECKING
+from numbers import Number
+from asyncua import Client, Node, ua
+from asyncua.common.ua_utils import string_to_val
+from openfactory.schemas.devices import Device
+from openfactory.schemas.connectors.opcua import OPCUAConnectorSchema
+from openfactory.schemas.command_header import CommandEnvelope
+from openfactory.assets import Asset, AssetAttribute
+from openfactory.assets.utils import openfactory_timestamp
+from .subscription import SubscriptionHandler
+from .utils import get_node_by_path, normalize_value
+
+if TYPE_CHECKING:
+    from .main import OPCUAGateway
+
+
+class DeviceMonitor:
+    """
+    Manage the lifecycle of an OPC UA monitored device.
+
+    Each device gets its own monitor instance, which handles:
+    - Parsing connector schema
+    - Establishing OPC UA sessions
+    - Discovering OPC UA methods and exposing OpenFactory commands
+    - Reading configured constants
+    - Subscribing to variables and events
+    - Updating asset attributes in Kafka/ksqlDB
+    - Handling reconnects and cleanup
+    """
+
+    def __init__(self, device: Device, app: OPCUAGateway):
+        """
+        Initialize monitoring of a given device.
+
+        Args:
+            device (Device): The device definition, including UUID and connector schema.
+            app (OPCUAGateway): The OPCUAGateway application instance used to access shared state
+        """
+        self.device = device
+        self.app = app
+        self.dev_uuid = device.uuid
+        self.asset = Asset(device.uuid, ksqlClient=app.ksql)
+        self.global_producer = app.global_producer
+        self.schema = OPCUAConnectorSchema(**device.connector.model_dump())
+        self.subscription = None
+        self._connection_error = False
+        self.methods = {}
+        self.log = app.logger
+
+    async def run(self) -> None:
+        """
+        Main entry point for monitoring loop.
+
+        Keeps trying to connect and monitor the device until cancelled.
+        Reconnects automatically on errors with a small backoff.
+        """
+        self.log.info(f"Starting monitor task for {self.dev_uuid}")
+        while True:
+            try:
+                await self._run_session()
+                self._connection_error = False
+            except asyncio.CancelledError:
+                await self._cleanup()
+                raise
+            except Exception as e:
+                if "BadNoMatch" in str(e):
+                    self.log.error(f"[{self.dev_uuid}] Device cannot be resolved with {self.schema.server.uri}: {e}")
+                    await self._cleanup()
+                    break
+                if not self._connection_error:
+                    self.log.error(f"[{self.dev_uuid}] OPC UA client error: {type(e).__name__}: {e}")
+                    self.log.debug(traceback.format_exc())
+                    self.log.error(f"[{self.dev_uuid}] Will attempt to connect again as soon as device is back online ...")
+                    self._connection_error = True
+                try:
+                    self.global_producer.send(
+                        asset_uuid=self.dev_uuid,
+                        asset_attribute=AssetAttribute(id='avail', value="UNAVAILABLE", tag="Availability", type="Events")
+                    )
+                except Exception:
+                    pass
+                await asyncio.sleep(2)  # backoff before reconnect
+
+    async def _run_session(self) -> None:
+        """
+        Establish a session, discover configured resources,
+        and subscribe to variables and events.
+
+        Runs until the connection is lost. A reconnect is triggered
+        by exceptions from the keepalive loop.
+        """
+        async with Client(self.schema.server.uri) as client:
+            self.log.info(f"Connecting to OPC UA server {self.schema.server.uri}")
+            handler = SubscriptionHandler(self.dev_uuid, self.app, client)
+            self.subscription = await client.create_subscription(
+                period=float(self.schema.server.subscription.publishing_interval),
+                handler=handler,
+            )
+
+            await self._discover_methods(client)
+            await self._read_constants(client)
+            await self._subscribe_variables(client, handler)
+            await self._subscribe_events(client)
+
+            self.global_producer.send(
+                asset_uuid=self.dev_uuid,
+                asset_attribute=AssetAttribute(id='avail', value="AVAILABLE", tag="Availability", type="Events")
+            )
+            self.log.info(f"[{self.dev_uuid}] Connected to OPC UA server at {self.schema.server.uri}")
+
+            await self._keepalive_loop(client)
+
+    async def call_opcua_method(self, cmd: str, envelope: CommandEnvelope) -> Any | None:
+        """
+        Call an OPC UA method with its arguments.
+
+        Args:
+            cmd (str): Command name
+            envelope (CommandEnvelope): Command envelope containing header and named arguments
+
+        Returns:
+            Any | None: Result from the OPC UA method call, or None if the call fails.
+        """
+        # Get method metadata from cache
+        parent_node = self.methods[cmd]["parent_object"]
+        method_node = self.methods[cmd]["method_node"]
+        input_vtypes = self.methods[cmd]["input_vtypes"]
+        name_to_index = self.methods[cmd]["name_to_index"]
+
+        # Extract arguments dict from envelope
+        args_dict = envelope.arguments or {}
+
+        # Prepare positional argument list for OPC UA
+        ua_args: list[ua.Variant] = [None] * len(input_vtypes)
+
+        for name, val_str in args_dict.items():
+            if name not in name_to_index:
+                self.log.warning(f"[{self.dev_uuid}] Unknown argument '{name}' for command '{cmd}'")
+                continue
+            idx = name_to_index[name]
+            vtype = input_vtypes[idx]
+            ua_args[idx] = ua.Variant(string_to_val(val_str, vtype), vtype)
+
+        # Fill any missing arguments with empty strings
+        for i, arg in enumerate(ua_args):
+            if arg is None:
+                ua_args[i] = ua.Variant("", input_vtypes[i])
+
+        try:
+            self.log.debug(f"[{self.dev_uuid}] Calling OPC UA method '{cmd}' with arguments {ua_args}")
+            result = await parent_node.call_method(method_node, *ua_args)
+            self.log.debug(f"[{self.dev_uuid}] Method '{cmd}' result: {result}")
+            return result
+
+        except Exception as e:
+            self.log.error(f"[{self.dev_uuid}] Method call failed for '{cmd}': {e}")
+
+    def _normalize_cmd(self, name: str) -> str:
+        """
+        Normalize a command name into a safe, ASCII-only identifier.
+
+        This function transforms the input string by:
+          1. Converting Unicode characters to closest ASCII equivalents (e.g., 'ä' → 'a').
+          2. Replacing any non-alphanumeric characters with underscores.
+          3. Collapsing multiple consecutive underscores into a single underscore.
+          4. Stripping leading and trailing underscores.
+
+        Args:
+            name (str): The original command name to normalize.
+
+        Returns:
+            str: A normalized, ASCII-only string suitable for use as a safe internal identifier.
+
+        Examples:
+            >>> self._normalize_cmd("Generate Code")
+            'Generate_Code'
+            >>> self._normalize_cmd("Öl Pumpe Start!")
+            'Ol_Pumpe_Start'
+            >>> self._normalize_cmd("Temp °C")
+            'Temp_C'
+        """
+        # Normalize unicode (ä → a, etc.)
+        name = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode()
+
+        # Replace non-alphanumeric with underscore
+        name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+
+        # Collapse multiple underscores
+        name = re.sub(r"_+", "_", name)
+
+        return name.strip("_")
+
+    async def _discover_methods(self, client: Client) -> None:
+        """
+        Discover OPC UA methods, expose them as OpenFactory Asset attributes,
+        and subscribe to corresponding OpenFactory commands.
+
+        Args:
+            client (Client): Connected OPC UA client
+        """
+        if not self.schema.methods:
+            return
+
+        for local_name, method_cfg in self.schema.methods.items():
+
+            self.log.debug(f"[{self.dev_uuid}] Add Methods for {local_name}")
+            if method_cfg.browse_path is not None:
+                methods_node = await get_node_by_path(client, method_cfg.browse_path)
+            else:
+                methods_node = await get_node_by_path(client, method_cfg.node_id)
+
+            for method_node in await methods_node.get_methods():
+                method = await method_node.read_browse_name()
+                command = self._normalize_cmd(method.Name)
+                description = await method_node.read_description()
+                self.log.info(f"[{self.dev_uuid}] Add Method: {command} ({description.Text})")
+
+                # Build structured method contract that will be added to OpenFactory Asset
+                method_contract = {
+                    "description": description.Text if description else "",
+                    "arguments": []
+                }
+
+                vtypes = []
+                name_to_index = {}
+                try:
+                    # Get the InputArguments property
+                    input_args_node = await method_node.get_child("0:InputArguments")
+                    input_args_values = await input_args_node.read_value()
+
+                    # Discover variant type of input arguments
+                    for pos, spec in enumerate(input_args_values):
+                        vtype = ua.VariantType(spec.DataType.Identifier)
+                        vtypes.append(vtype)
+                        name_to_index[spec.Name] = pos
+
+                        # Log structured information
+                        desc = spec.Description.Text if spec.Description else "No description"
+                        self.log.info(
+                            f"[{self.dev_uuid}] [{command}] Input argument: "
+                            f"Name='{spec.Name}' "
+                            f"Type={vtype.name} "
+                            f"Description='{desc}'"
+                        )
+
+                        method_contract["arguments"].append({
+                            "name": spec.Name,
+                            "description": desc
+                        })
+
+                except ua.UaStatusCodeError as e:
+                    if e.code == ua.StatusCodes.BadNoMatch:
+                        # No InputArguments found; ua_args remains an empty list
+                        input_args_values = []
+                    else:
+                        raise
+
+                # store reference to OPC UA method (map between OpenFactory command and OPC UA method)
+                self.methods[command] = {
+                    "parent_object": methods_node,
+                    "method_node": method_node,
+                    "input_vtypes": vtypes,
+                    "name_to_index": name_to_index,
+                }
+
+                # add method to Asset
+                self.asset.add_attribute(
+                    asset_attribute=AssetAttribute(
+                        id=command,
+                        value=json.dumps(method_contract),
+                        type='Method',
+                        tag='Method'
+                    )
+                )
+
+                # add OpenFactory command to Asset
+                self.asset.add_attribute(
+                    asset_attribute=AssetAttribute(
+                        id=f"{command}_CMD",
+                        value="",
+                        type='OpenFactory',
+                        tag='Method.Command'
+                    )
+                )
+
+                # subscribe to OpenFactory command directed to the Asset
+                def on_cmd(msg_key, msg_value, cmd=command):
+                    try:
+                        # Parse JSON string into CommandEnvelope
+                        envelope = CommandEnvelope.parse_raw(msg_value['VALUE'])
+                    except Exception as e:
+                        self.log.error(f"[{self.dev_uuid}] Failed to parse CommandEnvelope for '{cmd}': {e}")
+                        return
+
+                    # Schedule the OPC UA method call with typed envelope
+                    asyncio.create_task(self.call_opcua_method(cmd=cmd, envelope=envelope))
+
+                self.asset.subscribe_to_attribute(f'{command}_CMD', on_cmd)
+
+    async def _read_constants(self, client: Client) -> None:
+        """
+        Read all configured constants and populate the OpenFactory Asset.
+
+        Args:
+            client (Client): Connected OPC UA client
+        """
+        if not self.schema.constants:
+            return
+        for local_name, const_cfg in self.schema.constants.items():
+            try:
+                if const_cfg.browse_path is not None:
+                    const_node = await get_node_by_path(client, const_cfg.browse_path)
+                else:
+                    const_node = client.get_node(const_cfg.node_id)
+
+                dv = await const_node.read_data_value()
+                attr = AssetAttribute(
+                    id=local_name,
+                    value=normalize_value(dv.Value.Value),
+                    type="Samples" if isinstance(dv.Value.Value, Number) else "Events",
+                    tag=const_cfg.tag,
+                    timestamp=openfactory_timestamp(dv.SourceTimestamp)
+                    )
+                self.asset.add_attribute(asset_attribute=attr)
+                self.log.info(f"[{self.dev_uuid}] Acquired constant '{local_name}' ({const_node.nodeid.to_string()}): {dv.Value.Value}")
+            except ValueError as e:
+                self.log.error(f"[{self.dev_uuid}] Failed to read '{local_name}' ({const_node.nodeid.to_string()}):{e}")
+            except Exception as e:
+                self.log.error(
+                    f"[{self.dev_uuid}] Failed to to read '{local_name}' ({const_node.nodeid.to_string()}): {e}",
+                    exc_info=True
+                    )
+
+    async def _subscribe_variables(self, client: Client, handler: SubscriptionHandler) -> None:
+        """
+        Subscribe to all configured variables and configure write-back
+        for writable variables.
+
+        Args:
+            client (Client): Connected OPC UA client
+            handler (SubscriptionHandler): Handles variable updates.
+        """
+        if not self.schema.variables:
+            return
+        for local_name, var_cfg in self.schema.variables.items():
+            try:
+                if var_cfg.browse_path is not None:
+                    var_node = await get_node_by_path(client, var_cfg.browse_path)
+                else:
+                    var_node = client.get_node(var_cfg.node_id)
+                await self.subscription.subscribe_data_change(
+                    var_node,
+                    queuesize=var_cfg.queue_size,
+                    sampling_interval=var_cfg.sampling_interval,
+                )
+                handler.node_map[var_node] = {
+                    "local_name": local_name,
+                    "tag": var_cfg.tag,
+                    "deadband": var_cfg.deadband,
+                    "last_val": None
+                    }
+                self.log.info(f"[{self.dev_uuid}] Subscribed to variable '{local_name}' ({var_node.nodeid.to_string()})")
+
+                # Discover server-side access level
+                user_access_level = await var_node.get_user_access_level()
+                is_writable = ua.AccessLevel.CurrentWrite in user_access_level
+
+                # Policy (schema) vs capability (server)
+                if var_cfg.access_level == "rw":
+                    if is_writable:
+                        loop = asyncio.get_running_loop()
+
+                        async def _write_value(value: str, node: Node, name: str) -> None:
+                            """ Write value to OPC UA server. """
+                            try:
+                                v_type = await node.read_data_type_as_variant_type()
+                                await node.write_value(value, varianttype=v_type)
+                            except Exception as e:
+                                self.log.error(
+                                    f"[{self.dev_uuid}] Failed to write variable '{name}' ({node.nodeid.to_string()}): {e}",
+                                    exc_info=True,
+                                )
+
+                        def on_variable_update(msg_subject: str, msg_value: dict, node: Node = var_node, name: str = local_name) -> None:
+                            """ Callback for attribute changes, capturing loop variables. """
+                            async def _check_and_write(value: str):
+                                """ Avoid infinity loops. """
+                                current_val = await node.read_value()
+                                if value != current_val:
+                                    self.log.debug(f"[{self.dev_uuid}] Updating variable '{name}' ({node.nodeid.to_string()}) with '{value}'")
+                                    await _write_value(value, node=node, name=name)
+
+                            loop.create_task(_check_and_write(msg_value['VALUE']))
+
+                        # Schedule write-back to OPC UA server if OpenFactory detects a change
+                        self.asset.subscribe_to_attribute(local_name, on_variable_update)
+                        self.log.info(
+                            f"[{self.dev_uuid}] Allow OpenFactory to write to "
+                            f"variable '{local_name}' ({var_node.nodeid.to_string()})"
+                            )
+                    else:
+                        self.log.warning(
+                            f"[{self.dev_uuid}] Variable '{local_name}' ({var_node.nodeid.to_string()}) "
+                            f"declared as rw but server reports it as read-only"
+                        )
+
+            except ValueError as e:
+                self.log.error(f"[{self.dev_uuid}] Failed to subscribe to variable '{local_name}' ({var_node.nodeid.to_string()}):{e}")
+            except Exception as e:
+                self.log.error(
+                    f"[{self.dev_uuid}] Failed to subscribe to variable '{local_name}' ({var_node.nodeid.to_string()}): {e}",
+                    exc_info=True
+                    )
+
+    async def _subscribe_events(self, client: Client, ) -> None:
+        """
+        Subscribe to events.
+
+        Args:
+            client (Client): Connected OPC UA client
+        """
+        if not self.schema.events:
+            return
+        for local_name, event_cfg in self.schema.events.items():
+            try:
+                if event_cfg.browse_path is not None:
+                    event_node = await get_node_by_path(client, event_cfg.browse_path)
+                    node_id = event_node.nodeid.to_string()
+                else:
+                    node_id = event_cfg.node_id
+                await self.subscription.subscribe_events(node_id)
+                self.log.info(f"[{self.dev_uuid}] Subscribed to events '{local_name}' ({node_id})")
+            except Exception as e:
+                self.log.error(f"[{self.dev_uuid}] Failed to subscribe to events '{local_name}': {e}", exc_info=True)
+
+    async def _keepalive_loop(self, client: Client) -> None:
+        """
+        Keep the session alive by reading the server's Objects folder periodically.
+
+        Args:
+            client (Client): Connected OPC UA client.
+
+        Raises:
+            Exception: If the server becomes unreachable.
+        """
+        poll_node = client.nodes.objects
+        self.log.info(f"[{self.dev_uuid}] Keepalive by polling server Objects folder")
+
+        while True:
+            await asyncio.sleep(1)
+            await poll_node.read_display_name()  # exception triggers reconnect
+
+    async def _cleanup(self) -> None:
+        """
+        Cleanup resources when monitor task is cancelled.
+
+        Ensures asset availability is set to UNAVAILABLE and deletes the subscription.
+        """
+        self.log.info(f"[{self.dev_uuid}] Monitor task cancelled; cleaning up")
+        try:
+            self.global_producer.send(
+                asset_uuid=self.dev_uuid,
+                asset_attribute=AssetAttribute(id='avail', value="UNAVAILABLE", tag="Availability", type="Events")
+            )
+            self.log.info(f"[{self.dev_uuid}] Sent UNAVAILABLE status to OpenFactory")
+        except Exception as e:
+            self.log.error(f"[{self.dev_uuid}] Unable to send UNAVAILABLE status to OpenFactory: {e}")
+        try:
+            if self.subscription:
+                await self.subscription.delete()
+        except Exception:
+            pass
+        self.log.info(f"[{self.dev_uuid}] OPC UA connector removed successfully")

--- a/src/connectors/opcua/gateway/src/subscription.py
+++ b/src/connectors/opcua/gateway/src/subscription.py
@@ -1,0 +1,187 @@
+"""
+OPC UA subscription handler module for the Gateway.
+
+This module defines the `SubscriptionHandler` class, which processes
+data change and event notifications from OPC UA servers. Notifications
+are enriched with metadata, classified as 'Samples', 'Events', or
+'Condition', and forwarded to the global Kafka producer (`global_producer`).
+
+Key components:
+- `SubscriptionHandler`: Handles both data changes and event notifications
+  for a specific OPC UA device UUID.
+"""
+
+from __future__ import annotations
+from numbers import Number
+from typing import Any, TYPE_CHECKING
+from asyncua import ua, Client
+from asyncua.common.node import Node
+from asyncua.common.subscription import DataChangeNotif
+from openfactory.assets import AssetAttribute
+from openfactory.assets.utils import openfactory_timestamp, current_timestamp
+from .utils import opcua_data_timestamp, opcua_event_timestamp, normalize_value
+
+if TYPE_CHECKING:
+    from .main import OPCUAGateway
+
+
+class SubscriptionHandler:
+    """
+    Handle OPC UA subscription notifications.
+
+    Processes both data change and event notifications received from OPC UA
+    subscriptions, enriches them with metadata, and forwards them to the
+    OpenFactory ingestion pipeline.
+    """
+
+    def __init__(self, opcua_device_uuid: str, app: OPCUAGateway, opcua_client: Client):
+        """
+        Initialize the SubscriptionHandler.
+
+        Args:
+            opcua_device_uuid (str): UUID of the device.
+            app (OPCUAGateway): The OPCUAGateway instance used to access shared state
+            opcua_client (Client): OPC UA client used to resolve event type metadata.
+
+        Attributes:
+            node_map (dict): Cache mapping OPC UA nodes to subscription metadata,
+                including the OpenFactory attribute ID, tag name, deadband
+                configuration, and last transmitted value.
+        """
+        self.opcua_device_uuid = opcua_device_uuid
+        self.logger = app.logger
+        self.gateway_id = app.asset_uuid
+        self.global_producer = app.global_producer
+        self.client = opcua_client
+
+        # Cache mapping: Node -> {"local_name", "tag", "deadband", "last_val"}
+        self.node_map: dict = {}
+
+    async def datachange_notification(self, node: Node, val: object, data: DataChangeNotif) -> None:
+        """
+        Handle OPC UA data change notifications.
+
+        This method is called by the OPC UA client subscription handler whenever
+        a monitored variable's value changes. It enriches the notification with
+        metadata and timestamp and forwards the update into the OpenFactory pipeline.
+
+        Numeric values are sent as 'Samples', non-numeric as 'Events'.
+        Numeric values are suppressed if the change does not exceed the configured deadband.
+        Values with bad or uncertain StatusCode are reported as 'UNAVAILABLE'.
+
+        Args:
+            node (Node): The OPC UA node that triggered the data change.
+            val (object): The new value of the variable.
+            data (DataChangeNotif): Subscription notification wrapper
+                containing the monitored item, DataValue, timestamps,
+                and status information.
+        """
+
+        # Extract variable name
+        info = self.node_map.get(node, {})
+        local_name = info.get("local_name", "<unknown>")
+        tag = info.get("tag", "<unknown>")
+        deadband = info.get("deadband", 0)
+
+        # normalize value
+        val = normalize_value(val)
+
+        # Determine OpenFactory type based on value type
+        ofa_type = "Samples" if isinstance(val, Number) else "Events"
+        # Case for Boolean variables (they will appear as 'true'/'false' in Kafka but Python consider them as numbers)
+        if isinstance(val, bool):
+            ofa_type = 'Events'
+
+        # Extract DataValue
+        data_value: ua.DataValue = data.monitored_item.Value
+
+        # check status
+        if not data_value.StatusCode.is_good():
+            self.logger.warning(f"Received bad / uncertain value for {local_name} ({tag}): StatusCode={data_value.StatusCode}")
+            val = "UNAVAILABLE"
+
+        # verify deadband
+        if ofa_type == "Samples" and val != "UNAVAILABLE":
+            last_val = info.get("last_val", None)
+            if last_val is not None and abs(val - float(last_val)) <= deadband:
+                return
+            self.node_map[node]["last_val"] = val
+
+        self.logger.debug(f"DataChange: {local_name}:({tag}) -> {val}")
+
+        device_timestamp = opcua_data_timestamp(data.monitored_item.Value)
+        attribute = AssetAttribute(
+            id=local_name,
+            value=val,
+            type=ofa_type,
+            tag=tag,
+            timestamp=openfactory_timestamp(device_timestamp),
+            )
+
+        try:
+            self.global_producer.send(
+                asset_uuid=self.opcua_device_uuid,
+                asset_attribute=attribute,
+                ingestion_timestamp=current_timestamp()
+            )
+            self.logger.debug(f"Sent data to Kafka {str(attribute)}")
+        except Exception as e:
+            self.logger.error(f"Failed to send data to Kafka for {self.opcua_device_uuid}: {e}")
+            return
+
+    async def event_notification(self, event: Any) -> None:
+        """
+        Handle OPC UA event notifications.
+
+        This callback is invoked when the client receives an event notification
+        from the server (e.g., alarms, conditions, or system events). It extracts
+        key fields such as message, severity, source, and timestamp,
+        and forwards them as an OpenFactory attribute.
+
+        Args:
+            event (Any): The OPC UA event object delivered by the subscription.
+        """
+        try:
+            message = getattr(event, "Message", None)
+            severity = getattr(event, "Severity", None)
+            source_name = getattr(event, "SourceName", "opcua")
+            event_type = getattr(event, "EventType", None)
+            tag = "OPCUAEvent"
+            if event_type:
+                event_type_node = self.client.get_node(event_type)
+                browse_name = await event_type_node.read_browse_name()
+                tag = browse_name.Name
+
+            if message and hasattr(message, "Text"):
+                message_text = message.Text
+            else:
+                message_text = str(message)
+
+            if severity:
+                message_text = f"{message_text} (Severity: {severity})"
+
+            self.logger.debug(f"Event from {source_name}: {message_text}")
+
+        except Exception as e:
+            self.logger.error(f"Error parsing event: {e}, raw event={event}")
+            message_text = "UNAVAILABLE"
+
+        device_timestamp = opcua_event_timestamp(event)
+        attribute = AssetAttribute(
+            id=f"{source_name}_event",
+            value=message_text,
+            type="Condition",
+            tag=tag,
+            timestamp=openfactory_timestamp(device_timestamp),
+            )
+
+        try:
+            self.global_producer.send(
+                asset_uuid=self.opcua_device_uuid,
+                asset_attribute=attribute,
+                ingestion_timestamp=current_timestamp()
+            )
+            self.logger.debug(f"Sent data to Kafka {str(attribute)}")
+        except Exception as e:
+            self.logger.error(f"Failed to send event to Kafka for {self.opcua_device_uuid}: {e}")
+            return

--- a/src/connectors/opcua/gateway/src/utils.py
+++ b/src/connectors/opcua/gateway/src/utils.py
@@ -1,0 +1,172 @@
+"""
+Utility functions for the OPC UA Gateway.
+
+This module provides helper functions for:
+
+- Extracting timestamps from OPC UA DataValues and events.
+- Resolving OPC UA nodes from browse paths.
+- Normalizing OPC UA values into Python-native representations.
+
+Functions:
+- opcua_data_timestamp(data)
+- opcua_event_timestamp(event)
+- get_node_by_path(client, path)
+- normalize_value(val)
+"""
+
+from typing import Any
+from asyncua import ua, Client, Node
+from datetime import datetime, timezone
+
+
+def opcua_data_timestamp(data: ua.DataValue) -> datetime:
+    """
+    Extract the most relevant timestamp from an OPC UA DataValue.
+
+    Priority order:
+        1. SourceTimestamp (preferred, device time)
+        2. ServerTimestamp (fallback, server processing time)
+        3. Current system time (last resort)
+
+    Args:
+        data (ua.DataValue): The OPC UA DataValue to extract timestamps from.
+
+    Returns:
+        datetime: The extracted timestamp as a UTC-aware datetime object.
+    """
+    if data.SourceTimestamp:
+        return data.SourceTimestamp
+    if data.ServerTimestamp:
+        return data.ServerTimestamp
+    return datetime.now(timezone.utc)
+
+
+def opcua_event_timestamp(event: Any) -> datetime:
+    """
+    Extract the most relevant timestamp from an OPC UA event.
+
+    Priority order:
+        1. event.Time
+        2. event.ReceiveTime
+        3. Current UTC time
+
+    Args:
+        event (Any): OPC UA event object.
+
+    Returns:
+        datetime: The extracted timestamp as a UTC-aware datetime object.
+    """
+    event_time = getattr(event, "Time", None)
+    receive_time = getattr(event, "ReceiveTime", None)
+    if hasattr(event_time, "isoformat"):
+        return event_time
+    if hasattr(receive_time, "isoformat"):
+        return receive_time
+    return datetime.now(timezone.utc)
+
+
+async def get_node_by_path(client: Client, path: str) -> Node:
+    """
+    Resolve and return an OPC UA node using a slash-separated browse path.
+
+    The path must be given in the format ``"ns:Name/ns:ChildName/..."``,
+    where each segment specifies a namespace index and a browse name.
+    For example: ``"0:Objects/2:MyDevice/2:Sensor1"``.
+
+    If the first element ends with ``"Root"``, it will be skipped because
+    the search always starts from the OPC UA Root node.
+
+    Args:
+        client (Client): Connected OPC UA client
+        path (str): Slash-separated list of browse path segments in the form ``"namespace_index:BrowseName"``.
+
+    Returns:
+        Node: The resolved OPC UA node corresponding to the provided path.
+
+    Raises:
+        ValueError:
+            If any segment in the provided path cannot be resolved.
+    """
+    elements = path.split("/")
+
+    # Normalize: skip Root if included
+    if elements[0].endswith("Root"):
+        elements = elements[1:]
+
+    root = client.get_root_node()
+
+    try:
+        node = await root.get_child(elements)
+        return node
+
+    except ua.UaStatusCodeError as exc:
+        # Find out where it broke
+        node = root
+        resolved_segments = []
+
+        failed_segment = None
+
+        for segment in elements:
+            try:
+                node = await node.get_child([segment])
+                resolved_segments.append(segment)
+            except ua.UaStatusCodeError:
+                failed_segment = segment
+                break
+
+        # browse children at the level where the failure occurred
+        try:
+            children = await node.get_children()
+            child_names = []
+            for c in children:
+                bname = await c.read_browse_name()
+                child_names.append(f"{bname.NamespaceIndex}:{bname.Name}")
+        except Exception:
+            child_names = []
+
+        # Build error message
+        available_children = ", ".join(child_names) if child_names else "<none>"
+        msg = (
+            f"Failed to resolve OPC UA path: '{path}'.\n"
+            f"Could not resolve segment: '{failed_segment}'.\n"
+            f"Path resolved up to: '{'/'.join(resolved_segments) or '<root>'}'.\n"
+            f"Server error: {exc}.\n"
+            f"Children available at this level: {available_children}"
+        )
+
+        raise ValueError(msg) from exc
+
+
+def normalize_value(val: object) -> Any:
+    """
+    Convert OPC UA-specific value types into JSON-serializable
+    Python-native representations.
+
+    Args:
+        val (object): The new value of the variable.
+
+    Returns:
+        Any: Normalized Python representation of the input value.
+    """
+    # LocalizedText → return its text
+    if isinstance(val, ua.LocalizedText):
+        return val.Text
+
+    # ByteString → return hex string instead of raw bytes
+    if isinstance(val, (bytes, bytearray)):
+        return list(val)
+
+    # Arrays → normalize each element
+    if isinstance(val, list):
+        return [normalize_value(v) for v in val]
+
+    # ua.Variant: unwrap
+    if isinstance(val, ua.Variant):
+        return normalize_value(val.Value)
+
+    # datetime → return as str
+    if isinstance(val, datetime):
+        return str(val)
+
+    # fallback: return as-is
+    return val


### PR DESCRIPTION
### Refactor the OPC UA connector using the new connector framework

In new version the OPC UA connectors are now OpenFactory Applications and can be deployed as any other application.

A typical configuration file looks like
```yaml
apps:

  opcua-coordinator:
    uuid: OPCUA-COORDINATOR
    image: ghcr.io/openfactoryio/opcua-coordinator:<VERSION>
    environment:
      - LOG_LEVEL=DEBUG
    networks:
      - factory-net

  opcua-gateway-1:
    uuid: OPCUA-GATEWAY-1
    image: ghcr.io/openfactoryio/opcua-gateway:<VERSION>
    environment:
      - LOG_LEVEL=DEBUG
      - KAFKA_LINGER_MS=10
    networks:
      - factory-net

  opcua-gateway-2:
    uuid: OPCUA-GATEWAY-2
    image: ghcr.io/openfactoryio/opcua-gateway:<VERSION>
    environment:
      - LOG_LEVEL=DEBUG
      - KAFKA_LINGER_MS=10
    networks:
      - factory-net
```