### PR TITLE
Capture ingestion_timestamp when data is received by the gateway

### DIFF
--- a/src/connectors/opcua/gateway/src/subscription.py
+++ b/src/connectors/opcua/gateway/src/subscription.py
@@ -76,6 +76,7 @@ class SubscriptionHandler:
                 containing the monitored item, DataValue, timestamps,
                 and status information.
         """
+        ingestion_timestamp = current_timestamp()
 
         # Extract variable name
         info = self.node_map.get(node, {})
@@ -122,7 +123,7 @@ class SubscriptionHandler:
             self.global_producer.send(
                 asset_uuid=self.opcua_device_uuid,
                 asset_attribute=attribute,
-                ingestion_timestamp=current_timestamp()
+                ingestion_timestamp=ingestion_timestamp
             )
             self.logger.debug(f"Sent data to Kafka {str(attribute)}")
         except Exception as e:
@@ -141,6 +142,8 @@ class SubscriptionHandler:
         Args:
             event (Any): The OPC UA event object delivered by the subscription.
         """
+        ingestion_timestamp = current_timestamp()
+
         try:
             message = getattr(event, "Message", None)
             severity = getattr(event, "Severity", None)
@@ -179,7 +182,7 @@ class SubscriptionHandler:
             self.global_producer.send(
                 asset_uuid=self.opcua_device_uuid,
                 asset_attribute=attribute,
-                ingestion_timestamp=current_timestamp()
+                ingestion_timestamp=ingestion_timestamp
             )
             self.logger.debug(f"Sent data to Kafka {str(attribute)}")
         except Exception as e:

--- a/src/connectors/shdr/gateway/src/main.py
+++ b/src/connectors/shdr/gateway/src/main.py
@@ -133,6 +133,7 @@ class SHDRGateway(BaseGateway):
 
                 while True:
                     line = await reader.readline()
+                    ingestion_timestamp = current_timestamp()
                     if not line:
                         # socket closed
                         self.logger.warning("SHDR stream closed")
@@ -158,7 +159,7 @@ class SHDRGateway(BaseGateway):
                                 tag=datapoint.tag,
                                 timestamp=timestamp
                                 ),
-                            ingestion_timestamp=current_timestamp()
+                            ingestion_timestamp=ingestion_timestamp
                             )
                         self.logger.debug(f"[{device.uuid}] ({timestamp}) {key}={value} tag={datapoint.tag}")
 


### PR DESCRIPTION
## Summary

This PR changes the computation of `ingestion_timestamp` in the SHDR and OPC UA gateways.

Previously, the `ingestion_timestamp` was computed when observations were published to Kafka. As a result, it reflected the publication time rather than the time the gateway received the data.

This change captures the `ingestion_timestamp` immediately after the gateway receives data from the source and reuses that value when publishing the resulting observations.

## Changes

* SHDR gateway

  * Capture `ingestion_timestamp` immediately after an SHDR record is received from the TCP stream.
  * Reuse the same timestamp for all observations extracted from the received record.

* OPC UA gateway

  * Capture `ingestion_timestamp` immediately upon receiving data change and event notifications.
  * Reuse the captured timestamp when publishing observations to Kafka.

## Result

The `ingestion_timestamp` now consistently represents the time at which the gateway ingested the data, independent of when the corresponding Kafka messages are produced.

Closes #<issue-number>
