### PR TITLE
Handle OPC UA event parsing failures without raising UnboundLocalError

### DIFF
--- a/src/connectors/opcua/gateway/src/subscription.py
+++ b/src/connectors/opcua/gateway/src/subscription.py
@@ -149,6 +149,7 @@ class SubscriptionHandler:
             severity = getattr(event, "Severity", None)
             source_name = getattr(event, "SourceName", "opcua")
             event_type = getattr(event, "EventType", None)
+
             tag = "OPCUAEvent"
             if event_type:
                 event_type_node = self.client.get_node(event_type)
@@ -165,26 +166,25 @@ class SubscriptionHandler:
 
             self.logger.debug(f"Event from {source_name}: {message_text}")
 
+            device_timestamp = opcua_event_timestamp(event)
+            attribute = AssetAttribute(
+                id=f"{source_name}_event",
+                value=message_text,
+                type="Condition",
+                tag=tag,
+                timestamp=openfactory_timestamp(device_timestamp),
+            )
+
         except Exception as e:
             self.logger.error(f"Error parsing event: {e}, raw event={event}")
-            message_text = "UNAVAILABLE"
-
-        device_timestamp = opcua_event_timestamp(event)
-        attribute = AssetAttribute(
-            id=f"{source_name}_event",
-            value=message_text,
-            type="Condition",
-            tag=tag,
-            timestamp=openfactory_timestamp(device_timestamp),
-            )
+            return
 
         try:
             self.global_producer.send(
                 asset_uuid=self.opcua_device_uuid,
                 asset_attribute=attribute,
-                ingestion_timestamp=ingestion_timestamp
+                ingestion_timestamp=ingestion_timestamp,
             )
             self.logger.debug(f"Sent data to Kafka {str(attribute)}")
         except Exception as e:
             self.logger.error(f"Failed to send event to Kafka for {self.opcua_device_uuid}: {e}")
-            return


### PR DESCRIPTION
## Handle OPC UA event parsing failures without raising UnboundLocalError

This PR improves the robustness of OPC UA event handling by ensuring that event parsing failures do not result in secondary exceptions.

Previously, if an exception occurred while parsing an OPC UA event, the error was logged but the method continued execution. Since some local variables were initialized inside the parsing logic and used afterwards, this could lead to an `UnboundLocalError`, masking the original parsing error.

This change returns immediately after logging a parsing error, preventing the construction and publication of an invalid event.

## Changes

* Return immediately when parsing an OPC UA event fails.
* Prevent `UnboundLocalError` caused by uninitialized local variables.
* Preserve the original parsing error in the logs.
* Ensure that only successfully parsed OPC UA events are published to Kafka.

## Result

The event notification handler now fails gracefully when an OPC UA event cannot be parsed, avoiding secondary exceptions and improving error reporting.

Closes #<issue-number>
