### PR TITLE
Delegate asset deregistration to the gateway

### DIFF
--- a/src/connectors/common/gateway.py
+++ b/src/connectors/common/gateway.py
@@ -8,6 +8,7 @@ from openfactory.apps import OpenFactoryFastAPIApp, ofa_method
 from openfactory.schemas.devices import Device
 from openfactory.assets import Asset, AssetAttribute
 from openfactory.apps.attributefield import SampleAttribute
+from openfactory.utils import deregister_asset
 from . import gateway_metrics
 
 PROMETHEUS_METRICS_PATH = "/metrics"
@@ -260,6 +261,7 @@ class BaseGateway(OpenFactoryFastAPIApp):
     ):
         self.logger.info(f"Deregistering device {device_uuid}")
         self.disconnect_device(device_uuid)
+        deregister_asset(device_uuid, ksqlClient=self.ksql, bootstrap_servers=self.bootstrap_servers)
         self._device_count = self._device_count - 1
         self.device_count = self._device_count
         gateway_metrics.GATEWAY_DEVICE_COUNT.set(self._device_count)

--- a/src/connectors/opcua/gateway/src/monitor.py
+++ b/src/connectors/opcua/gateway/src/monitor.py
@@ -473,20 +473,8 @@ class DeviceMonitor:
             await poll_node.read_display_name()  # exception triggers reconnect
 
     async def _cleanup(self) -> None:
-        """
-        Cleanup resources when monitor task is cancelled.
-
-        Ensures asset availability is set to UNAVAILABLE and deletes the subscription.
-        """
+        """ Cleanup resources when monitor task is cancelled. """
         self.log.info(f"[{self.dev_uuid}] Monitor task cancelled; cleaning up")
-        try:
-            self.global_producer.send(
-                asset_uuid=self.dev_uuid,
-                asset_attribute=AssetAttribute(id='avail', value="UNAVAILABLE", tag="Availability", type="Events")
-            )
-            self.log.info(f"[{self.dev_uuid}] Sent UNAVAILABLE status to OpenFactory")
-        except Exception as e:
-            self.log.error(f"[{self.dev_uuid}] Unable to send UNAVAILABLE status to OpenFactory: {e}")
         try:
             if self.subscription:
                 await self.subscription.delete()

--- a/tests/connectors/common/test_gateway.py
+++ b/tests/connectors/common/test_gateway.py
@@ -313,16 +313,24 @@ class BaseGatewayTests(unittest.TestCase):
         self.assertEqual(len(gateway.connected_devices), 1)
         self.assertEqual(gateway.connected_devices[0].uuid, "DEVICE1")
 
-    @patch.object(BaseGateway, "_wait_coordinator_available")
+    @patch("connectors.common.gateway.deregister_asset")
     @patch("connectors.common.gateway.Asset")
-    def test_deregister_device_disconnects_device(self, asset_cls, _wait):
-        """ Test deregistration disconnects the device. """
+    def test_deregister_device_disconnects_device(self, asset_cls, mock_deregister_asset):
+        """ Test deregistration disconnects the device and removes its asset. """
+
         asset_cls.return_value = Mock()
 
         gateway = ExampleGateway(ksqlClient=FakeKSQLClient(), test_mode=True)
+
         gateway.deregister_device("DEVICE1")
 
         self.assertEqual(gateway.disconnected_devices, ["DEVICE1"])
+
+        mock_deregister_asset.assert_called_once_with(
+            "DEVICE1",
+            ksqlClient=gateway.ksql,
+            bootstrap_servers=gateway.bootstrap_servers,
+        )
 
     @patch("connectors.common.gateway.Asset", FakeCoordinatorAsset)
     def test_initialization_discovers_correct_coordinator_type(self):


### PR DESCRIPTION
# Delegate asset deregistration to the gateway

## Summary

This PR updates the gateway lifecycle so that it deregisters OpenFactory assets after successfully disconnecting a device.

This change completes the responsibility shift introduced in OpenFactory, where asset lifecycle management is delegated to the component that owns the device's runtime state.

## Motivation

Previously, the OpenFactory deployment layer performed asset deregistration during connector teardown. As a result, it was responsible for publishing the final lifecycle state of assets even though it did not manage device connectivity.

With the corresponding OpenFactory changes, connectors now only request that a device be disconnected. It is the gateway that knows when the disconnection has completed successfully and is therefore the appropriate component to deregister the asset.

## Changes

* Invoke `deregister_asset()` after successfully disconnecting a device.
* Update the unit tests to verify that asset deregistration is triggered during device deregistration.

## Benefits

* Asset lifecycle is owned by the component managing device connectivity.
* Clear separation of responsibilities between OpenFactory and gateway implementations.
* Asset state accurately reflects the runtime state of connected devices.
* Simpler deployment layer with consistent lifecycle ownership.
