### PR TITLE
Add configurable HTTP request logging for Coordinators and Gateways

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -328,6 +328,7 @@ Connector implementations may expose additional metrics.
 | `KAFKA_BROKER`        | Kafka bootstrap servers         | Yes      |
 | `KSQLDB_URL`          | ksqlDB server URL               | Yes      |
 | `APPLICATION_VERSION` | Application version for metrics | Optional |
+| `LOG_HTTP_REQUESTS`   | Enables HTTP request logging when set to `1`, `true`, `yes`, or `on`  case-insensitive). Defaults to `false`. | Optional |
 | `NODE_HOSTNAME`       | Node hostname for metrics       | Optional |
 
 ---

--- a/src/connectors/common/coordinator.py
+++ b/src/connectors/common/coordinator.py
@@ -28,6 +28,11 @@ class BaseCoordinator(OpenFactoryFastAPIApp):
             loglevel: Logging level (e.g., ``INFO``, ``DEBUG``).
             test_mode: Enables test mode (disables live Kafka/ksql interaction).
 
+        Environment variables:
+            LOG_HTTP_REQUESTS: Enables HTTP request logging when set to one
+                of ``1``, ``true``, ``yes``, or ``on`` (case-insensitive).
+                Defaults to ``false``.
+
         See also:
             :class:`OpenFactoryFastAPIApp` for full initialization
             details and environment variable handling.
@@ -35,7 +40,10 @@ class BaseCoordinator(OpenFactoryFastAPIApp):
         if self.CONNECTOR_NAME is None:
             raise NotImplementedError(f"{self.__class__.__name__} must define CONNECTOR_NAME")
 
-        super().__init__(*args, **kwargs)
+        log_http_requests = os.getenv("LOG_HTTP_REQUESTS", "false").strip().lower() in {
+            "1", "true", "yes", "on"
+            }
+        super().__init__(*args, **kwargs, log_http_requests=log_http_requests)
 
         # expose OFA app inside FastAPI
         self.api.state.ofa_app = self

--- a/src/connectors/common/gateway.py
+++ b/src/connectors/common/gateway.py
@@ -36,6 +36,11 @@ class BaseGateway(OpenFactoryFastAPIApp):
             loglevel: Logging level (e.g., ``INFO``, ``DEBUG``).
             test_mode: Enables test mode (disables live Kafka/ksql interaction).
 
+        Environment variables:
+            LOG_HTTP_REQUESTS: Enables HTTP request logging when set to one
+                of ``1``, ``true``, ``yes``, or ``on`` (case-insensitive).
+                Defaults to ``false``.
+
         See also:
             :class:`OpenFactoryFastAPIApp` for full initialization
             details and environment variable handling.
@@ -43,7 +48,10 @@ class BaseGateway(OpenFactoryFastAPIApp):
         if self.CONNECTOR_NAME is None:
             raise NotImplementedError(f"{self.__class__.__name__} must define CONNECTOR_NAME")
 
-        super().__init__(*args, **kwargs)
+        log_http_requests = os.getenv("LOG_HTTP_REQUESTS", "false").strip().lower() in {
+            "1", "true", "yes", "on"
+            }
+        super().__init__(*args, **kwargs, log_http_requests=log_http_requests)
 
         # expose OFA app inside FastAPI
         self.api.state.ofa_app = self

--- a/tests/connectors/common/test_coordinator.py
+++ b/tests/connectors/common/test_coordinator.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+import os
 from unittest.mock import patch
 from openfactory.schemas.devices import Device
 from connectors.common.coordinator import BaseCoordinator
@@ -111,6 +112,26 @@ class BaseCoordinatorTests(unittest.TestCase):
     """
     Unittests for BaseCoordinator
     """
+
+    @patch.dict(os.environ, {"LOG_HTTP_REQUESTS": "true"})
+    def test_log_http_requests_enabled(self):
+        """ Test LOG_HTTP_REQUESTS enables HTTP request logging. """
+        coordinator = ExampleCoordinator(
+            ksqlClient=FakeKSQLClient(),
+            test_mode=True,
+        )
+
+        self.assertTrue(coordinator.log_http_requests)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_log_http_requests_disabled_by_default(self):
+        """ Test HTTP request logging is disabled by default. """
+        coordinator = ExampleCoordinator(
+            ksqlClient=FakeKSQLClient(),
+            test_mode=True,
+        )
+
+        self.assertFalse(coordinator.log_http_requests)
 
     def test_valid_device_fixture(self):
         """

--- a/tests/connectors/common/test_gateway.py
+++ b/tests/connectors/common/test_gateway.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 from unittest.mock import Mock, patch
 from openfactory.exceptions import OFAException
 from connectors.common.gateway import BaseGateway
@@ -128,6 +129,28 @@ class BaseGatewayTests(unittest.TestCase):
     """
     Unittests for BaseGateway.
     """
+
+    @patch.dict(os.environ, {"LOG_HTTP_REQUESTS": "true"})
+    @patch("connectors.common.gateway.Asset", FakeCoordinatorAsset)
+    def test_log_http_requests_enabled_from_environment(self):
+        """ Test LOG_HTTP_REQUESTS enables HTTP request logging. """
+        gateway = ExampleGateway(
+            ksqlClient=FakeKSQLClient(),
+            test_mode=True
+        )
+
+        self.assertTrue(gateway.log_http_requests)
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("connectors.common.gateway.Asset", FakeCoordinatorAsset)
+    def test_log_http_requests_disabled_by_default(self):
+        """ Test HTTP request logging is disabled by default. """
+        gateway = ExampleGateway(
+            ksqlClient=FakeKSQLClient(),
+            test_mode=True
+        )
+
+        self.assertFalse(gateway.log_http_requests)
 
     def test_requires_connector_name(self):
         """ Test that CONNECTOR_NAME must be defined. """


### PR DESCRIPTION
# Add configurable HTTP request logging for Coordinators and Gateways

## Summary

This PR adds support for enabling HTTP request logging through the `LOG_HTTP_REQUESTS` environment variable.

Both `BaseCoordinator` and `BaseGateway` now read this environment variable during initialization and pass the resulting boolean value to `OpenFactoryFastAPIApp`.

## Changes

* Added support for the `LOG_HTTP_REQUESTS` environment variable in:

  * `BaseCoordinator`
  * `BaseGateway`
* Accepted truthy values are:

  * `1`
  * `true`
  * `yes`
  * `on`
    (case-insensitive)
* HTTP request logging remains disabled by default.
* Added unit tests covering the new configuration.
* Updated constructor docstrings to document the new environment variable.
* Updated the Connector Coordination Framework documentation with the new configuration option.

## Motivation

HTTP request logging is valuable for troubleshooting and debugging connector deployments. Making it configurable through an environment variable provides a simple way to enable request logging when needed without changing application code, while preserving the existing default behavior.

## Testing

* Added unit tests verifying that `LOG_HTTP_REQUESTS` is correctly interpreted.
* Verified that HTTP request logging is disabled when the environment variable is not set.
* Verified that existing Coordinator and Gateway tests continue to pass.

## Backward Compatibility

This change is fully backward compatible. Existing deployments are unaffected unless `LOG_HTTP_REQUESTS` is explicitly configured.
