### PR TITLE
fix VS Code using .venv instead of the Dev Container Python

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,6 @@
     ],
     "python.analysis.extraPaths": [
         "./src"
-    ]
+    ],
+    "python-envs.defaultEnvManager": "ms-python.python:system"
 }


### PR DESCRIPTION
## VS Code using .venv instead of the Dev Container Python

Configure VS Code to use the system Python environment when working inside the Dev Container.

## Problem

If the repository contains a workspace `.venv` (used for local development), VS Code may select it instead of the Dev Container's system Python. This can result in:

* Test discovery failing in the VS Code Test Explorer.
* Import errors such as `ModuleNotFoundError`.
* The Python REPL using `.venv/bin/python` instead of `/usr/local/bin/python`.

## Solution

Configure the Python Environments extension to use the system environment manager by adding:

```json
"python-envs.defaultEnvManager": "ms-python.python:system"
```

to the workspace settings.

This ensures VS Code uses the Dev Container's Python interpreter instead of the workspace `.venv`.
