### PR TITLE
Fix OPC UA Gateway sending an invalid command during method discovery

### DIFF
--- a/src/connectors/opcua/gateway/src/monitor.py
+++ b/src/connectors/opcua/gateway/src/monitor.py
@@ -477,23 +477,13 @@ class DeviceMonitor:
                     )
                 )
 
-                # add OpenFactory command to Asset
-                self.asset.add_attribute(
-                    asset_attribute=AssetAttribute(
-                        id=f"{command}_CMD",
-                        value="",
-                        type='OpenFactory',
-                        tag='Method.Command'
-                    )
-                )
-
                 # subscribe to OpenFactory command directed to the Asset
                 def on_cmd(msg_key, msg_value, cmd=command):
                     try:
                         # Parse JSON string into CommandEnvelope
                         envelope = CommandEnvelope.parse_raw(msg_value['VALUE'])
                     except Exception as e:
-                        self.log.error(f"[{self.dev_uuid}] Failed to parse CommandEnvelope for '{cmd}': {e}")
+                        self.log.error(f"[{self.dev_uuid}] Failed to parse CommandEnvelope for '{cmd}' with args '{msg_value['VALUE']}': {e}")
                         return
 
                     # Schedule the OPC UA method call with typed envelope


### PR DESCRIPTION
# Fix OPC UA Gateway sending an invalid command during method discovery

## Summary

During OPC UA Gateway startup, the `_discover_methods()` routine calls `asset.add_attribute()`. This method has the side effect of sending an empty command to the OpenFactory pipeline, resulting in an invalid command validation error:

```text
validation error for CommandEnvelope
  Invalid JSON: EOF while parsing a value at line 1 column 0 [type=json_invalid, input_value='', input_type=str]
```

Since no attribute registration is required during method discovery, this call is unnecessary.

## Changes

* Remove the unnecessary `asset.add_attribute()` call from `_discover_methods()`.
* Prevent the gateway from sending an empty command during startup.
* Eliminate the resulting `CommandEnvelope` validation error.

## Why

Method discovery should only inspect and register available methods. Invoking `asset.add_attribute()` introduces an unintended side effect by publishing an empty command to the OpenFactory pipeline, which is unrelated to method discovery and causes avoidable startup errors.

This change removes that unnecessary side effect while preserving the intended method discovery behavior.

## Related

* https://github.com/openfactoryio/openfactory-core/issues/393
