### PR TITLE
Make BaseGateway recover from coordinator startup synchronization race

### DIFF
--- a/src/connectors/common/gateway.py
+++ b/src/connectors/common/gateway.py
@@ -65,7 +65,7 @@ class BaseGateway(OpenFactoryFastAPIApp):
         self._discover_coordinator()
 
         # wait coordinator becomes available
-        self.coordinator = Asset(asset_uuid=self.COORDINATOR_UUID, ksqlClient=self.ksql)
+        self.coordinator: Asset = Asset(asset_uuid=self.COORDINATOR_UUID, ksqlClient=self.ksql)
         self._wait_coordinator_available()
 
         # register gateway with coordinator
@@ -152,6 +152,11 @@ class BaseGateway(OpenFactoryFastAPIApp):
                     raise OFAException(f"Coordinator {self.COORDINATOR_UUID} did not become available within {timeout} seconds.")
 
             self.logger.info(f"Coordinator {self.COORDINATOR_UUID} not yet available")
+
+            # Recover from the startup race where the coordinator's AVAIL update was
+            # missed by NATS and had not yet been materialized in ksqlDB when the
+            # Asset was initially created.
+            self.coordinator.resync_state()
 
     def _fetch_assigned_devices(self):
         query = f"""

--- a/tests/connectors/common/test_gateway.py
+++ b/tests/connectors/common/test_gateway.py
@@ -410,6 +410,30 @@ class BaseGatewayTests(unittest.TestCase):
 
         coordinator.wait_until.assert_called()
 
+    def test_wait_coordinator_available_resyncs_after_failed_wait(self):
+        """ Test coordinator state is resynchronized after a failed wait. """
+
+        gateway = object.__new__(ExampleGateway)
+
+        coordinator = Mock()
+        coordinator.wait_until.return_value = False
+        coordinator.resync_state.side_effect = RuntimeError("stop")
+
+        object.__setattr__(gateway, "coordinator", coordinator)
+        object.__setattr__(gateway, "COORDINATOR_UUID", "TEST-COORDINATOR")
+        object.__setattr__(gateway, "logger", Mock())
+
+        with patch("time.time", side_effect=[0, 1]):
+            with self.assertRaises(RuntimeError):
+                gateway._wait_coordinator_available(timeout=30)
+
+        coordinator.wait_until.assert_called_once_with(
+            attribute_id="avail",
+            value="AVAILABLE",
+            timeout=30,
+        )
+        coordinator.resync_state.assert_called_once()
+
     @patch.object(BaseGateway, "_wait_coordinator_available")
     @patch("connectors.common.gateway.Asset", FakeCoordinatorAsset)
     def test_register_device_records_gateway_attribute(self, _wait):


### PR DESCRIPTION
# Make `BaseGateway` recover from coordinator startup synchronization race

## Summary

Improve `BaseGateway` to recover from a startup race where the coordinator becomes available before the gateway has fully synchronized its local coordinator `Asset`.

## Problem

During startup, `BaseGateway` creates an `Asset` instance for the coordinator and waits for its `avail` attribute to become `AVAILABLE`.

In rare cases, the following sequence can occur:

1. The coordinator publishes its `avail=AVAILABLE` update to Kafka.
2. The gateway creates the coordinator `Asset`, which starts listening for NATS updates.
3. The `Asset` immediately synchronizes its initial state from ksqlDB.
4. ksqlDB has not yet materialized the `avail=AVAILABLE` update and therefore still returns the previous value.

As a result, the gateway observes neither the original NATS notification nor the updated state from ksqlDB. The coordinator `Asset` remains permanently stale and `wait_until()` never observes the coordinator becoming available.

## Solution

If waiting for the coordinator times out, `BaseGateway` now explicitly refreshes the coordinator `Asset` from ksqlDB before retrying.

This is implemented by calling:

```python
self.coordinator.resync_state()
```

between successive `wait_until()` attempts.

Once ksqlDB has materialized the coordinator state, the next retry succeeds automatically without requiring a gateway restart.

## Testing

A new unit test verifies the recovery path by ensuring that `BaseGateway` invokes:

```python
self.coordinator.resync_state()
```

after a failed `wait_until()` attempt before retrying.

## Acceptance Criteria

* `BaseGateway` automatically recovers from the coordinator startup synchronization race.
* Gateway startup succeeds even if the initial coordinator `avail` update is not observed.
* No restart is required once ksqlDB has materialized the coordinator state.
* Unit tests verify that `resync_state()` is invoked after a failed wait attempt.
